### PR TITLE
fix: pin `@types/react` to 17.0.21

### DIFF
--- a/next-expo-solito/package.json
+++ b/next-expo-solito/package.json
@@ -15,6 +15,7 @@
     "sync:tamagui": "${TAMAGUI_PATH:-$HOME/tamagui}/starters-sync.sh"
   },
   "resolutions": {
+    "@types/react": "17.0.21",
     "cacache": "16.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
This'll prevent typescript from showing 'Component cannot be used as a JSX component.'